### PR TITLE
fix: panic it if error occurs when proxy is starting

### DIFF
--- a/pkg/proxy/proxies/nginx/nginx.go
+++ b/pkg/proxy/proxies/nginx/nginx.go
@@ -122,11 +122,9 @@ func (f *nginx) Run(stopCh <-chan struct{}) {
 		"default-http-backend": f.defaultHTTPbackend,
 		"sidecar":              f.sidecar,
 	})
-	defer log.Info("Shutting down nginx proxy")
 
 	if err := f.ensureDefaultHTTPBackend(); err != nil {
-		log.Error("ensure default http backend service error", log.Fields{"err": err})
-		return
+		log.Panicf("Ensure default http backend service error, %v", err)
 	}
 
 	// lb controller has waited all the informer synced


### PR DESCRIPTION
<!-- PR template; please answer the questions. -->

**What this PR does**


**why we need it**
nginx proxy will ensure default backend when getting started. 
If some error occurs when it communicate with apiserver, the nginx proxy fail and controller does not known anything. 

**Special notes for your reviewer**:
