### PR TITLE
fix: ignore provider deployment of zero replica

### DIFF
--- a/pkg/provider/f5/f5.go
+++ b/pkg/provider/f5/f5.go
@@ -240,11 +240,12 @@ func (f *f5) sync(lb *lbapi.LoadBalancer, dps []*appsv1.Deployment) error {
 		// 1. deployment does not have auto-generated prefix
 		// 2. if there are more than one active controllers, there may be many valid deployments.
 		//    But we only need one.
+		if *dp.Spec.Replicas == 0 {
+			continue
+		}
 		if !strings.HasPrefix(dp.Name, lb.Name+providerNameSuffix) || updated {
-			if *dp.Spec.Replicas == 0 {
-				continue
-			}
 			// scale unexpected deployment replicas to zero
+			log.Infof("Deployment %v is duplicated, set replicas to zero", dp.Name)
 			copy := dp.DeepCopy()
 			replica := int32(0)
 			copy.Spec.Replicas = &replica


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

当代码异常创建多个 provider deployment 副本时，会出现两个副本反复被设置 replica（根据 list 出来的顺序），导致 deployment 一直被更新，此修复能够忽略 replicas 为 0 的 deployment

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @hanxueluo 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
